### PR TITLE
optimize Pipe.Wait

### DIFF
--- a/script.go
+++ b/script.go
@@ -849,7 +849,7 @@ func (p *Pipe) Tee(writers ...io.Writer) *Pipe {
 // useful for waiting until concurrent filters have completed (see
 // [Pipe.Filter]).
 func (p *Pipe) Wait() {
-	_, err := io.ReadAll(p)
+	_, err := io.Copy(io.Discard, p)
 	if err != nil {
 		p.SetError(err)
 	}


### PR DESCRIPTION
use io.Copy with io.Discard instead of io.ReadAll to avoid allocating a buffer just to throw it away